### PR TITLE
Updated margin order in fieldset legend

### DIFF
--- a/scss/foundation/components/_forms.scss
+++ b/scss/foundation/components/_forms.scss
@@ -279,8 +279,8 @@ $select-hover-bg-color: scale-color($select-bg-color, $lightness: -3%) !default;
   legend {
     background: $legend-bg;
     font-weight: $legend-font-weight;
-    margin-#{$default-float}: rem-calc(-3);
     margin: 0;
+    margin-#{$default-float}: rem-calc(-3);
     padding: $legend-padding;
   }
 }


### PR DESCRIPTION
This is so the margin actually gets rendered. This was in the opposite
order before in 5.5.0 - I think it was reversed for code-standards, no
point if its broken though.
